### PR TITLE
Update search api interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,6 @@
 	},
 	"optionalDependencies": {
 		"terser": "^5.14.2"
-	}
+	},
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/modules/AddMusicModule/AddMusicModule.tsx
+++ b/src/modules/AddMusicModule/AddMusicModule.tsx
@@ -66,25 +66,19 @@ const AddMusicModule = () => {
 			{!!loadingQuery && <Spinner />}
 			{!loadingQuery && hits && (
 				<div className='searchResults'>
-					{hits.map(song => {
-						if (song._highlightResult.title.matchLevel!)
-							return (
-								<div
-									className='result'
-									key={song.path}
-									onClick={() => {
-										if (tab) addSong(song.objectID);
-									}}
-								>
-									<div className='name' dangerouslySetInnerHTML={{ __html: song._highlightResult.title.value }}></div>
-									<div
-										className='author'
-										dangerouslySetInnerHTML={{ __html: song._highlightResult.authors.value }}
-									></div>
-									<div className='icon'></div>
-								</div>
-							);
-					})}
+					{hits.map(song => (
+						<div
+							className='result'
+							key={song.id}
+							onClick={() => {
+								if (tab) addSong(song.id);
+							}}
+						>
+							<div className='name'>{song.title}</div>
+							<div className='author'>{song.authors}</div>
+							<div className='icon'></div>
+						</div>
+					))}
 				</div>
 			)}
 		</div>

--- a/src/types/ISearchHit.ts
+++ b/src/types/ISearchHit.ts
@@ -8,15 +8,6 @@ export interface ISearchHighlight {
 export default interface ISearchHit {
 	authors: string;
 	key: string;
-	lastmodified: number;
-	objectID: string;
-	path: string;
+	id: string;
 	title: string;
-	_highlightResult: {
-		authors: ISearchHighlight;
-		key: ISearchHighlight;
-		lastmodified: ISearchHighlight;
-		path: ISearchHighlight;
-		title: ISearchHighlight;
-	};
 }


### PR DESCRIPTION
Jeg har ændret interfacet ISearchHit så det matcher de opdateringer jeg gerne vil lave på API'et. Jeg har opdateret API'et så det understøtter begge versioner midlertidigt, indtil disse opdateringer merges.

Det drejer sig bare om at objectID omdøbes til id og highlights fjernes, idet jeg kommer til at fjerne dependencies på Algolia.